### PR TITLE
added genome utilities

### DIFF
--- a/code/scripts/README.md
+++ b/code/scripts/README.md
@@ -97,9 +97,13 @@ Taxonomy utilities
 
 [**ranks_to_tree.py**](ranks_to_tree.py): Convert a genome-to-ranks table into a tree.
 
+**New** [**gtdb_to_taxdump.py**](gtdb_to_taxdump.py): Convert [GTDB](https://gtdb.ecogenomic.org/) taxonomy into NCBI taxdump style.
+
 
 Community analysis utilities
 ----------------------------
+
+**New** [**genomes_for_db.py**](genomes_for_db.py): Linearize, filter and concatenate multiple genome sequences into a single Fasta file for subsequent database building.
 
 [**gOTU_from_maps.py**](gOTU_from_maps.py): Generate a "gOTU table" from WGS sequence alignment results.
 

--- a/code/scripts/genomes_for_db.py
+++ b/code/scripts/genomes_for_db.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Generate a single Fasta file from multiple genome sequences.
+"""
+
+from os import listdir
+from os.path import join, splitext
+import re
+import gzip
+import bz2
+import lzma
+import argparse
+
+__author__ = 'Qiyun Zhu'
+__license__ = 'BSD-3-Clause'
+__version__ = '0.0.1-dev'
+__email__ = 'qiyunzhu@gmail.com'
+
+usage = """%(prog)s -i INPUT_DIR -o OUTPUT_FILE [options]"""
+
+description = """example:
+  %(prog)s -i multi_fna.gz_dir -o output.fna --concat --gap N*20
+"""
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        usage=usage, description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    arg = parser.add_argument
+    arg('-i', '--input', required=True,
+        help='input directory containing genome sequences (fna)')
+    arg('-o', '--output', required=True,
+        help='output multi-Fasta filename')
+    arg('-c', '--concat', action='store_true',
+        help='concatenate sequences of each genome')
+    arg('-g', '--gap', default='',
+        help=('fill sequence gaps with string, use "*" to indicate repeats, '
+              'e.g., "N*20"'))
+    arg('-e', '--ext',
+        help='filename extension following genome ID')
+    arg('-f', '--filt',
+        help=('exclude sequences with any of comma-delimited words in title, '
+              'e.g., "plasmid,phage"'))
+    arg('-n', '--ncbi', action='store_true',
+        help=('parse NCBI-style genome filenames, e.g., "GCF_123456789.1_'
+              'ASM123v1_genomic.fna.gz" will be given ID "G123456789"'))
+    for arg in parser._actions:
+        arg.metavar = '\b'
+    return parser.parse_args()
+
+
+def main():
+    # parser arguments
+    args = parse_args()
+
+    # generate gap string
+    gap = ''
+    if args.gap:
+        gap = args.gap
+        if '*' in gap:
+            str_, n_ = gap.rsplit('*', 1)
+            if n_.isdigit():
+                gap = str_ * int(n_)
+
+    # compressed filename pattern
+    zipdic = {'.gz': gzip, '.bz2': bz2, '.xz': lzma, '.lz': lzma}
+
+    # read input genome list
+    gs = {}
+    if args.ncbi:
+        ptn = re.compile(r'GC[FA]_([0-9]{9})\.[0-9]+_.*')
+    for fname in listdir(args.input):
+        g = ''
+
+        # custom extension
+        if args.ext:
+            if not fname.endswith(args.ext):
+                continue
+            g = fname[:-len(args.ext)].rstrip('.')
+
+        # auto-recognize
+        else:
+            g, ext = splitext(fname)
+            if len(ext) > 1 and ext in zipdic:
+                g, ext = splitext(g)
+        if g in gs:
+            raise ValueError('Duplicate genome ID "%s".' % g)
+
+        # parse NCBI filename
+        if args.ncbi:
+            m = ptn.match(g)
+            if m:
+                g = 'G%s' % m.group(1)
+
+        gs[g] = fname
+    print('Found %d genomes.' % len(gs))
+
+    # summary
+    nseq = 0
+    nchar = 0
+
+    # helper to read compressed files
+    def read(fname):
+        ext = splitext(fname)[1]
+        zipfunc = getattr(zipdic[ext], 'open') if ext in zipdic else open
+        return zipfunc(fname, 'rt')
+
+    # sequence title filter
+    if args.filt:
+        ptn = re.compile(
+            r'[^a-zA-Z0-9](%s)[^a-zA-Z0-9]' % args.filt.replace(',', '|'))
+
+        def filtseq(title):
+            return ptn.search(title, re.IGNORECASE) is not None
+
+    # output file
+    fo = open(args.output, 'w')
+
+    # store or write a sequence when finishing reading
+    def finseq():
+        nonlocal seq, nseq, nchar
+        if seq:
+            if not todel:
+                if args.concat:
+                    seqs.append(seq)
+                else:
+                    fo.write('%s\n' % seq)
+                nseq += 1
+                nchar += len(seq)
+            seq = ''
+
+    # parse input genome sequences
+    for g, fname in sorted(gs.items(), key=lambda x: x[0]):
+        if args.concat:
+            fo.write('>%s\n' % g)
+        fi = read(join(args.input, fname))
+        seqs = []
+        seq = ''
+        todel = False
+        for line in fi:
+            line = line.rstrip('\r\n')
+            if line.startswith('>'):
+                finseq()
+                todel = filtseq(line) if args.filt else False
+                if not args.concat and not todel:
+                    fo.write('%s\n' % line.split()[0])
+            else:
+                seq += line
+        fi.close()
+        finseq()
+        if args.concat:
+            fo.write('%s\n' % gap.join(seqs))
+    print('Parsed %d sequences (%d characters in total).'
+          % (nseq, nchar))
+
+    # finish writing
+    fo.close()
+    print('Output file %s written.' % args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/scripts/gtdb_to_taxdump.py
+++ b/code/scripts/gtdb_to_taxdump.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Convert GTDB taxonomy into NCBI style.
+
+Usage:
+    gtdb_to_taxdump.py gtdb_taxonomy.tsv
+    gtdb_to_taxdump.py bac120_taxonomy_r89.tsv ar122_taxonomy_r89.tsv
+
+Output:
+    nodes.dmp: NCBI-style nodes file.
+    names.dmp: NCBI-style names file.
+    taxid.map: genome ID to taxonomy ID map.
+
+Notes:
+    This script converts GTDB lineage strings (Greengenes-style) into an NCBI-
+    style taxonomy database (taxdump), in which each taxonomic unit is given
+    a unique numeric ID (a.k.a. TaxID). This ID is incremental, starting from 1
+    at the root, and increasing from higher ranks to lower ranks.
+
+    This script is generally applicable to Greengenes-style lineage strings.
+    However the following criteria must suffice: 1) All lineages have exactly
+    seven ranks, from domain (d) to species (s). 2) All ranks are filled (i.e.,
+    there are no gaps like "g__;". 3) At the same rank, all taxon names are
+    unique.
+
+    If you plan to use this script on custom lineage strings, you may need to
+    consider these criteria and modify the code accordingly.
+"""
+
+import fileinput
+
+__author__ = 'Qiyun Zhu'
+__license__ = 'BSD-3-Clause'
+__version__ = '0.0.1-dev'
+__email__ = 'qiyunzhu@gmail.com'
+
+ranks = ('domain', 'phylum', 'class', 'order', 'family', 'genus', 'species')
+
+
+def main():
+    """Reformat GTDB taxonomy into NCBI taxdump.
+    """
+    # genome to species map
+    g2species = {}
+
+    # taxon to parent map
+    taxon2parent = {x: {} for x in ranks}
+
+    # parse records
+    for line in fileinput.input():
+        g, lineage = line.rstrip().split('\t')
+
+        # start with root
+        parent = 'root'
+
+        # parse taxa in order
+        for i, taxon in enumerate(lineage.split(';')):
+            code, taxon = taxon.split('__')
+
+            # validate order of ranks
+            rank = ranks[i]
+            if code != rank[0]:
+                raise ValueError(f'Invalid rank code: {code}.')
+
+            # validate consistency with existing record
+            if taxon in taxon2parent[rank]:
+                if taxon2parent[rank][taxon] != parent:
+                    raise ValueError(f'Inconsistent parent: {taxon}.')
+
+            # add taxon to records
+            else:
+                taxon2parent[rank][taxon] = parent
+
+            # update parent
+            parent = taxon
+
+        # last taxon is species
+        if rank != 'species':
+            raise ValueError(f'Incomplete record: {parent}.')
+        g2species[g] = parent
+
+    # build taxonomy tree
+    taxdump = {'1': {'parent': '1', 'rank': 'no rank', 'name': 'root'}}
+
+    # current taxId (incremental)
+    cid = 1
+
+    # assign taxIds to taxa
+    parent2id = {'root': 1}
+    for rank in ranks:
+        taxon2id = {}
+        for taxon, parent in taxon2parent[rank].items():
+            cid += 1
+            taxdump[str(cid)] = {
+                'parent': str(parent2id[parent]), 'rank': rank, 'name': taxon}
+            taxon2id[taxon] = cid
+        parent2id = {k: v for k, v in taxon2id.items()}
+
+    # write genome to species taxId map
+    with open('taxid.map', 'w') as f:
+        for g, species in sorted(g2species.items()):
+            f.write(f'{g}\t{parent2id[species]}\n')
+
+    # write nodes.dmp and names.dmp
+    fo = open('nodes.dmp', 'w')
+    fa = open('names.dmp', 'w')
+    for id_, rec in sorted(taxdump.items(), key=lambda x: int(x[0])):
+        fo.write(f"{id_}\t|\t{rec['parent']}\t|\t{rec['rank']}\t|\n")
+        fa.write(f"{id_}\t|\t{rec['name']}\t|\t\t|\tscientific name\t|\n")
+    fo.close()
+    fa.close()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Added two Python scripts for meta'omics analyses:

1. `gtdb_to_taxdump.py`: Convert [GTDB](https://gtdb.ecogenomic.org/) taxonomy into NCBI taxdump style.
2. `genomes_for_db.py`: Linearize, filter and concatenate multiple genome sequences into a single Fasta file for subsequent database building.